### PR TITLE
Fixes add-on with SSL enabled

### DIFF
--- a/terminal/rootfs/etc/services.d/ttyd/run
+++ b/terminal/rootfs/etc/services.d/ttyd/run
@@ -26,7 +26,7 @@ ttyd_options+=(--port 7681)
 if hass.config.true 'ssl'; then
     ttyd_options+=(--ssl)
     ttyd_options+=(--ssl-cert "/ssl/$(hass.config.get 'certfile')")
-    ttyd_options+=(--ssl-key "/ss/$(hass.config.get 'keyfile')")
+    ttyd_options+=(--ssl-key "/ssl/$(hass.config.get 'keyfile')")
 fi
 
 # Add login credentials, when enabled.


### PR DESCRIPTION
# Proposed Changes

Fixes an issue where the Terminal add-on could not start, when having SSL enabled.

## Related Issues

#13